### PR TITLE
Call API from libpcap.so and operate tc filter more robustly

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,8 +5,6 @@ before:
 builds:
   - id: skbdump
     binary: skbdump
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
     goarch:
@@ -32,4 +30,3 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
-

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ Please download the latest binary in the [releases](https://github.com/jschwinge
 
 ### Requirements
 
-`tcpdump(8)` is required to generate cbpf bytecode, please install it.
+[libpcap](https://www.tcpdump.org/) is required for Linux, for Ubuntu:
+
+```bash
+apt install libpcap-dev
+```
 
 # Usage
 
@@ -27,7 +31,6 @@ Usage of skbdump:
   -i, --interface string       interface to capture (default "lo")
   -w, --pcap-filename string   output pcap filename (default "skbdump.pcap")
       --perf-output            use bpf_perf_event_output to lift payload size limit
-  -p, --priority uint32        filter priority (default 1)
   -s, --skb-filename string    output skb filename (default "skbdump.skb")
 ```
 
@@ -43,4 +46,5 @@ Please be aware that every capture will dump two files, one is `pcap` file which
 
 # Known Issues
 
-1. Currently the tool only supports capturing packets with maximum 1500 bytes in default mode.
+1. Currently the tool only supports capturing packets with maximum 1500 bytes in default mode (bpf queue output mode).
+2. Using perf output mode can capture payload larger than 1500 bytes, but it's likely to mess up the event order and get some events lost.

--- a/config.go
+++ b/config.go
@@ -12,7 +12,6 @@ import (
 
 type Config struct {
 	Iface         string
-	Priority      uint32
 	PerfOutput    bool
 	SkbFilename   string
 	PcapFilename  string
@@ -26,7 +25,6 @@ var (
 
 func initConfig() {
 	flag.StringVarP(&config.Iface, "interface", "i", "lo", "interface to capture")
-	flag.Uint32VarP(&config.Priority, "priority", "p", 1, "filter priority")
 	flag.BoolVarP(&config.PerfOutput, "perf-output", "", false, "use bpf_perf_event_output to lift payload size limit")
 	flag.StringVarP(&config.SkbFilename, "skb-filename", "s", "skbdump.skb", "output skb filename")
 	flag.StringVarP(&config.PcapFilename, "pcap-filename", "w", "skbdump.pcap", "output pcap filename")

--- a/internal/bpf/perf/bpf.go
+++ b/internal/bpf/perf/bpf.go
@@ -83,10 +83,10 @@ func (o *PerfBpfObjects) Load(cbpfFilter []bpf.Instruction) (err error) {
 }
 
 func (o *PerfBpfObjects) EgressFilter() *ebpf.Program {
-	return o.objs.OnIngress
+	return o.objs.OnEgress
 }
 func (o *PerfBpfObjects) IngressFilter() *ebpf.Program {
-	return o.objs.OnEgress
+	return o.objs.OnIngress
 }
 
 func (o *PerfBpfObjects) PollSkb(ctx context.Context) (_ <-chan internalbpf.Skb, err error) {

--- a/internal/bpf/queue/bpf.go
+++ b/internal/bpf/queue/bpf.go
@@ -74,10 +74,10 @@ func (o *QueueBpfObjects) Load(cbpfFilter []bpf.Instruction) (err error) {
 }
 
 func (o *QueueBpfObjects) EgressFilter() *ebpf.Program {
-	return o.objs.OnIngress
+	return o.objs.OnEgress
 }
 func (o *QueueBpfObjects) IngressFilter() *ebpf.Program {
-	return o.objs.OnEgress
+	return o.objs.OnIngress
 }
 
 func (o *QueueBpfObjects) PollSkb(ctx context.Context) (_ <-chan internalbpf.Skb, err error) {

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	if err = bpfObjects.Load(bpf.MustGenerateCbpf(config.PcapFilterExp)); err != nil {
+	if err = bpfObjects.Load(bpf.MustPcapCompile(config.PcapFilterExp)); err != nil {
 		return
 	}
 
@@ -52,14 +52,14 @@ func main() {
 			return
 		}
 
-		delIngress, e := device.AddIngressFilter(bpfObjects.IngressFilter(), config.Priority)
+		delIngress, e := device.AddIngressFilter(bpfObjects.IngressFilter())
 		if e != nil {
 			err = e
 			return
 		}
 		defer delIngress()
 
-		delEgress, e := device.AddEgressFilter(bpfObjects.EgressFilter(), config.Priority)
+		delEgress, e := device.AddEgressFilter(bpfObjects.EgressFilter())
 		if e != nil {
 			err = e
 			return


### PR DESCRIPTION
1. Get rid of exec(2)-ing tcpdump(7)
2. Delete priority argument as it's impossible to capture traffic after a direct-action filter, so no reason to specify a priority other than 1
3. Create tc filter with handle 0 rather than hardcode number, kernel will find the minimum available handle number.